### PR TITLE
Build changes to work around upstream packaging issue in poetry/isort, and to include pre-commit in venv packages.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 click>=8.*
 openai
+pre-commit

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -23,8 +23,9 @@ main(){
   source .venv/bin/activate
 
   pip3 install -r requirements.txt
-  pre-commit install
-  pre-commit run --all-files
+  python -m pre_commit autoupdate
+  python -m pre_commit install
+  python -m pre_commit run --all-files
 }
 
 main "$@"


### PR DESCRIPTION
1. Include pre-commit in requirements.txt so it is not required as a global dependency.
2. include pre-commit autoupdate in setup.sh to work around issue in upstream packages below.
 package described here https://github.com/PyCQA/isort/issues/2083\#issuecomment-1408159596

Tested:
System: MacOS 12.6.5 (Monterey) - ARM64.
Python 3.11.2 (homebrew, ARM64)
pip 23.1.2

looks good.

Fix for bug https://github.com/FabrizioCafolla/openai-chatgpt-opentranslator/issues/4
and bug https://github.com/FabrizioCafolla/openai-chatgpt-opentranslator/issues/3